### PR TITLE
Improve button focus state

### DIFF
--- a/match.js
+++ b/match.js
@@ -1,0 +1,3 @@
+var parent = require('../../stable/symbol/match');
+
+module.exports = parent;


### PR DESCRIPTION
Keyboard focus on primary buttons is hard to see which hurts accessibility. Update styles to increase outline contrast and add a 3px focus ring (and suppress focus on disabled buttons) to make keyboard navigation clear.